### PR TITLE
allow user disable electron's sandbox

### DIFF
--- a/src/electron/proc/index.ts
+++ b/src/electron/proc/index.ts
@@ -59,7 +59,9 @@ export class Electron {
       // electron starter
       const entry = path.join(__dirname, '../main/index');
       const args = [ entry ];
-
+      if (process.env.JEST_ELECTRON_NO_SANDBOX){
+        args.splice(0, 0, '--no-sandbox');
+      };
       const proc = spawn(
         electron as any,
         args,


### PR DESCRIPTION
### why user need to disable electron's sandbox :
1. users want to run `jest`/`jest-electron` as root.  without `--no-sandbox` option for `electron` , test cases will fail silently because `jest-electron` failed to spawn an `electron` process
2. Users of cypress have reported that the new Electron v5 seems to require --no-sandbox flag even when running as a regular non-root user. see https://github.com/cypress-io/cypress/pull/5458#issue-332256935

### security impact:
malicious javascript codes running within electron's renderer process are not sandboxed anymore and have the ability to harm the system. but here in `jest` test cases are trusted codes, so i think security impact is trivial.

###  who disables electron's sandbox on non-windows platform by default:
1, vscode. see https://github.com/microsoft/vscode/pull/81096
2, cypress. see https://github.com/cypress-io/cypress/pull/5458

fixes https://github.com/hustcc/jest-electron/issues/19
