### PR TITLE
fix: electron window should display error-prone source codes 

### DIFF
--- a/src/electron/renderer/dom.ts
+++ b/src/electron/renderer/dom.ts
@@ -97,9 +97,14 @@ function appendTestResultDOM(r) {
 
   if (!title) return;
 
+  let code = r.failureMessage ? r.failureMessage : '';
+
   const ts = r.testResults.map((tr) => {
     const { title, status, duration, failureMessages } = tr;
-    const code = Array.isArray(failureMessages) ? failureMessages[0] : '';
+
+    if (!code) {
+      code = Array.isArray(failureMessages) ? failureMessages[0] : '';
+    }
 
     return `<div class="test-result-block">
       <div class="test-result-info ${status}">


### PR DESCRIPTION
fixes: https://github.com/hustcc/jest-electron/issues/23

### what happened under the hood:

value of `r.testResults[0].failureMessages[0]`  ( `r` is what `runTest` function returns ) is:
~~~
Error: expect(received).toBe(expected) // Object.is equality
Expected: "trueaaaaaaaa"
Received: false
    at Object.<anonymous> (/root/icenter-next/tests/unit/electron.spec.ts:7:19)
    at Object.asyncJestTest (/root/icenter-next/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:102:37)
    at /root/icenter-next/node_modules/jest-jasmine2/build/queueRunner.js:43:12
    at new Promise (<anonymous>)
    at mapper (/root/icenter-next/node_modules/jest-jasmine2/build/queueRunner.js:26:19)
    at /root/icenter-next/node_modules/jest-jasmine2/build/queueRunner.js:73:41

~~~

value of `r.failureMessage` is:

~~~
● electron module › works properly when passed

    expect(received).toBe(expected) // Object.is equality

    Expected: "trueaaaaaaaa"
    Received: false

       5 |     const globalAny = globalThis as any;
       6 |     expect(console).toBe(globalAny.electronWindowConsole);
    >  7 |     expect(false).toBe(trueaaaaaaaa);
         |                   ^
       8 |   });
       9 | });
      10 |

      at Object.<anonymous> (tests/unit/electron.spec.ts:7:19)

~~~
### this PR is tested:
NOTE: i manually edited `node_modules\jest-electron\lib\electron\renderer\dom.js` and it worked well, but this typescript version itself is not tested, so please pay attention.
1. on both centos 7.4 and windows 7 platform.
2. with latest `jest` 24.9.0 and electron 6.1.4/6.1.7
3. when:
  3.1) only one test case has failed assertion
  3.2) two test cases both have failed assertion

