### PR TITLE
Fix require undefined when electron >= 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "dependencies": {
-    "electron": "^11.4.6",
+    "electron": "^12",
     "jest-haste-map": "~24.9.0",
     "jest-message-util": "~24.9.0",
     "jest-mock": "~24.9.0",

--- a/src/electron/main/window-pool.ts
+++ b/src/electron/main/window-pool.ts
@@ -97,6 +97,7 @@ export class WindowPool {
         webPreferences: {
           webSecurity: false,
           nodeIntegration: true,
+          contextIsolation: false
         },
       };
 


### PR DESCRIPTION
Electron 版本大于 12 时，默认不会在 renderer 进程开启 main 端的上下文（相关文档：[Context Isolation](https://github.com/electron/electron/blob/main/docs/tutorial/context-isolation.md#what-is-it)），因此会报 `require is not defined` 的错误。

![image](https://user-images.githubusercontent.com/28616219/152738681-8f922f0b-fd7f-4b55-98d0-85dcb1dd9f80.png)

通过添加 `contextIsolation` 配置可重新启用 require。
```
{      
  webPreferences: {
      contextIsolation: false
  }
}
```

另，升级 electron 版本的原因： 安装 electron 依赖源在 github 上，国内访问速度不理想。如果要通过 taobao 源加速，需要将 electron 的版本设为12及以上。（11及以下没法找到 taobao 源上正确的下载链接）