### PR TITLE
Upgrade to tslib v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jest-runtime": "~24.9.0",
     "jest-util": "~24.9.0",
     "throat": "^5.0.0",
-    "tslib": "^1.10.0"
+    "tslib": "^2.4.0"
   },
   "peerDependencies": {
     "jest": "^24.0.0"
@@ -49,7 +49,7 @@
     "react-dom": "^16.12.0",
     "rimraf": "^3.0.0",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.6.2"
+    "typescript": "^3.9.5"
   },
   "keywords": [
     "jest-electron",


### PR DESCRIPTION
This PR upgrade `tslib` to v`2.4.0` and `typescript` to v`3.9.5`.

This will help developer transitioning to new features of ECMAScript like destructuring & spead operator.

Fixes #52